### PR TITLE
Segmentation fault when file creation failed

### DIFF
--- a/src/create_file.c
+++ b/src/create_file.c
@@ -22,6 +22,7 @@ void create_file(char *file, int len)
   fp = fopen(file, "w");
   if (fp == NULL) {
       printf("Could not open file %s\n", file);
+      exit(EXIT_FAILURE);
   }
 
   srand(time(0)); // seed for generating random number


### PR DESCRIPTION
Hi,

I've added an exit() call to the if statement that checks if a file pointer is null.
At the moment it checks if the pointer is null, prints error message if it is, but then continues running the code anyway resulting in segmentation fault.

The example I have tested is trying to create the file in an area that requires root access, without having said root access.